### PR TITLE
Fix SyntaxWarnings on newer Python versions

### DIFF
--- a/src/autograder.py
+++ b/src/autograder.py
@@ -272,8 +272,8 @@ def evaluate(generateSolutions, testRoot, moduleDict, exceptionMap=ERROR_HINT_MA
         questionDicts[q] = questionDict
 
         # load test cases into question
-        tests = [t for t in os.listdir(subdir_path) if re.match('[^#~.].*\.test\Z', t)]
-        tests = [re.match('(.*)\.test\Z', t).group(1) for t in tests]
+        tests = [t for t in os.listdir(subdir_path) if re.match(r'[^#~.].*\.test\Z', t)]
+        tests = [re.match(r'(.*)\.test\Z', t).group(1) for t in tests]
         for t in sorted(tests):
             test_file = os.path.join(subdir_path, '%s.test' % t)
             solution_file = os.path.join(subdir_path, '%s.solution' % t)
@@ -338,16 +338,16 @@ if __name__ == '__main__':
     codePaths = options.studentCode.split(',')
     # moduleCodeDict = {}
     # for cp in codePaths:
-    #     moduleName = re.match('.*?([^/]*)\.py', cp).group(1)
+    #     moduleName = re.match(r'.*?([^/]*)\.py', cp).group(1)
     #     moduleCodeDict[moduleName] = readFile(cp, root=options.codeRoot)
     # moduleCodeDict['projectTestClasses'] = readFile(options.testCaseCode, root=options.codeRoot)
     # moduleDict = loadModuleDict(moduleCodeDict)
 
     moduleDict = {}
     for cp in codePaths:
-        moduleName = re.match('.*?([^/]*)\.py', cp).group(1)
+        moduleName = re.match(r'.*?([^/]*)\.py', cp).group(1)
         moduleDict[moduleName] = loadModuleFile(moduleName, os.path.join(options.codeRoot, cp))
-    moduleName = re.match('.*?([^/]*)\.py', options.testCaseCode).group(1)
+    moduleName = re.match(r'.*?([^/]*)\.py', options.testCaseCode).group(1)
     moduleDict['projectTestClasses'] = loadModuleFile(moduleName, os.path.join(options.codeRoot, options.testCaseCode))
 
 

--- a/src/testParser.py
+++ b/src/testParser.py
@@ -47,21 +47,21 @@ class TestParser(object):
         # read a property in each loop cycle
         while(i < len(lines)):
             # skip blank lines
-            if re.match('\A\s*\Z', lines[i]):
+            if re.match(r'\A\s*\Z', lines[i]):
                 test['__emit__'].append(("raw", raw_lines[i]))
                 i += 1
                 continue
-            m = re.match('\A([^"]*?):\s*"([^"]*)"\s*\Z', lines[i])
+            m = re.match(r'\A([^"]*?):\s*"([^"]*)"\s*\Z', lines[i])
             if m:
                 test[m.group(1)] = m.group(2)
                 test['__emit__'].append(("oneline", m.group(1)))
                 i += 1
                 continue
-            m = re.match('\A([^"]*?):\s*"""\s*\Z', lines[i])
+            m = re.match(r'\A([^"]*?):\s*"""\s*\Z', lines[i])
             if m:
                 msg = []
                 i += 1
-                while(not re.match('\A\s*"""\s*\Z', lines[i])):
+                while(not re.match(r'\A\s*"""\s*\Z', lines[i])):
                     msg.append(raw_lines[i])
                     i += 1
                 test[m.group(1)] = '\n'.join(msg)


### PR DESCRIPTION
Running `autograder.py` with Python 3.13.3 generated a few `SyntaxWarning` messages.

Fixed by using raw strings for regular expression patterns, also on `testparser.py`.

From the [Python docs](https://docs.python.org/3/library/re.html):

> Regular expressions use the backslash character ('\') to indicate special forms or to allow special characters to be used without invoking their special meaning. This collides with Python’s usage of the same character for the same purpose in string literals; for example, to match a literal backslash, one might have to write '\\\\' as the pattern string, because the regular expression must be \\, and each backslash must be expressed as \\ inside a regular Python string literal. Also, please note that any invalid escape sequences in Python’s usage of the backslash in string literals now generate a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning) and in the future this will become a [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError). This behaviour will happen even if it is a valid escape sequence for a regular expression.

> The solution is to use Python’s raw string notation for regular expression patterns; backslashes are not handled in any special way in a string literal prefixed with 'r'. So r"\n" is a two-character string containing '\' and 'n', while "\n" is a one-character string containing a newline. Usually patterns will be expressed in Python code using this raw string notation.